### PR TITLE
Tag map cache

### DIFF
--- a/addon-BBM.xml
+++ b/addon-BBM.xml
@@ -2554,6 +2554,7 @@ Your callback doesn't need to return anything. It allows you to modify on the fl
     <listener event_id="front_controller_pre_view" execute_order="10" callback_class="BBM_Protection_Helper_ContentProtection" callback_method="controllerPreView" active="1" hint="" description="BbCode content protection: get controller &amp; implementation"/>
     <listener event_id="init_dependencies" execute_order="10" callback_class="BBM_Listeners_AllInOne" callback_method="initTemplateHelpers" active="1" hint="" description="Init template helpers"/>
     <listener event_id="load_class" execute_order="10" callback_class="BBM_Listeners_AllInOne" callback_method="ModifyParser" active="1" hint="XenForo_BbCode_Parser" description="Modify Parser"/>
+    <listener event_id="load_class" execute_order="10" callback_class="BBM_Listeners_AllInOne" callback_method="BbCodes" active="1" hint="XenForo_DataWriter_DiscussionMessage_Post" description="Tag map cache invalidation"/>
     <listener event_id="load_class_bb_code" execute_order="10" callback_class="BBM_Listeners_AllInOne" callback_method="BbCodes" active="1" hint="" description="Listener for Formatter_Base, Autolink &amp; help"/>
     <listener event_id="load_class_controller" execute_order="10" callback_class="BBM_Listeners_AllInOne" callback_method="BbCodes" active="1" hint="" description="Adds support for display in Help Section"/>
     <listener event_id="load_class_datawriter" execute_order="10" callback_class="BBM_Listeners_AllInOne" callback_method="DataWriterAdmin" active="1" hint="" description="DataWriter Admin"/>
@@ -2658,6 +2659,24 @@ Your callback doesn't need to return anything. It allows you to modify on the fl
       <edit_format_params>BBM_Options_XenOptions::render_xen_tags</edit_format_params>
       <sub_options>*</sub_options>
       <relation group_id="bbm_bbcodemanager" display_order="610"/>
+    </option>
+    <option option_id="Bbm_TagsMap_Cache_Enabled" edit_format="onoff" data_type="boolean" can_backup="1">
+      <default_value>0</default_value>
+      <edit_format_params></edit_format_params>
+      <sub_options></sub_options>
+      <relation group_id="bbm_bbcodemanager" display_order="9100"/>
+    </option>
+    <option option_id="Bbm_TagsMap_Cache_Expiry" edit_format="spinbox" data_type="unsigned_integer" can_backup="1">
+      <default_value>604800</default_value>
+      <edit_format_params></edit_format_params>
+      <sub_options></sub_options>
+      <relation group_id="bbm_bbcodemanager" display_order="9130"/>
+    </option>
+    <option option_id="Bbm_TagsMap_Cache_Threshold" edit_format="spinbox" data_type="unsigned_integer" can_backup="1">
+      <default_value>5</default_value>
+      <edit_format_params></edit_format_params>
+      <sub_options></sub_options>
+      <relation group_id="bbm_bbcodemanager" display_order="9110"/>
     </option>
     <option option_id="Bbm_TagsMap_DebugInfo" edit_format="onoff" data_type="boolean" can_backup="1">
       <default_value>0</default_value>
@@ -3443,6 +3462,12 @@ Once activated, It will automatically override the private function "_parseTag()
 Default value: off.]]></phrase>
     <phrase title="option_Bbm_PreCache_XenTags" version_id="51" version_string="2.8.0"><![CDATA[XenForo Bb Codes to use with the pre-parser]]></phrase>
     <phrase title="option_Bbm_PreCache_XenTags_explain" version_id="51" version_string="2.8.0"><![CDATA[If you need to enable the pre-parser with some XenForo default Bb Codes, here's a quick way to do it. Use the CTRL key to select/unselect Bb Codes.]]></phrase>
+    <phrase title="option_Bbm_TagsMap_Cache_Enabled" version_id="61" version_string="3.0.4"><![CDATA[Tags Map Caching Enabled]]></phrase>
+    <phrase title="option_Bbm_TagsMap_Cache_Enabled_explain" version_id="61" version_string="3.0.4"><![CDATA[Enables caching of the Tag Map. For sufficiently long posts, building the tag map becomes expensive.]]></phrase>
+    <phrase title="option_Bbm_TagsMap_Cache_Expiry" version_id="61" version_string="3.0.4"><![CDATA[Cache Expiry]]></phrase>
+    <phrase title="option_Bbm_TagsMap_Cache_Expiry_explain" version_id="61" version_string="3.0.4"><![CDATA[The time in seconds, before the cache item naturally expires]]></phrase>
+    <phrase title="option_Bbm_TagsMap_Cache_Threshold" version_id="61" version_string="3.0.4"><![CDATA[Caching Threshold]]></phrase>
+    <phrase title="option_Bbm_TagsMap_Cache_Threshold_explain" version_id="61" version_string="3.0.4"><![CDATA[The threshold (in Milliseconds) before caching of the Tags Map for a piece of content.]]></phrase>
     <phrase title="option_Bbm_TagsMap_DebugInfo" version_id="0" version_string="1.0"><![CDATA[[DEBUG] Display Tags Map]]></phrase>
     <phrase title="option_Bbm_TagsMap_DebugInfo_explain" version_id="0" version_string="1.0"><![CDATA[This option will display the Tags Map and some debug information. This information can only be seen by admins.]]></phrase>
     <phrase title="option_Bbm_TagsMap_Disable" version_id="0" version_string="1.0"><![CDATA[Disable the Tags Map System]]></phrase>

--- a/upload/library/BBM/BbCode/Formatter/Base.php
+++ b/upload/library/BBM/BbCode/Formatter/Base.php
@@ -1892,7 +1892,7 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 		$extraKeys =  $this->_bbmExtraKeys;
 		$parsedKeySuffix = $this->_bbmPostfixParsedKey;
 		$parsedMessageKey = $messageKey . $parsedKeySuffix;
-        $cache_threshold = $options->Bbm_TagsMap_Cache_Threshold; // in milliseconds
+		$cache_threshold = $options->Bbm_TagsMap_Cache_Threshold; // in milliseconds
 		$cache_enabled = $options->Bbm_TagsMap_Cache_Enabled && ($content_type != '');
         
 		foreach($posts as $post_id => $post)
@@ -1917,61 +1917,61 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 				continue;
 			}
 			
-            $tag_cache = array();
-            $has_loaded_tags = false;
-            if ($cache_enabled)
-            {
-                $tag_cache = $bbcodesModel->getBbCodeTagCache($content_type, $post_id, $Bbm_TagsMap_GlobalMethod);
-                if (!empty($tag_cache))
-                {
-                    foreach($tag_cache as $tag)
-                    {
-                        $this->_bbCodesMap[$tag][] = $post_id;
-                    }
-                    $has_loaded_tags = true;
-                }
-            }
-            $time = microtime(true);
+			$tag_cache = array();
+			$has_loaded_tags = false;
+			if ($cache_enabled)
+			{
+				$tag_cache = $bbcodesModel->getBbCodeTagCache($content_type, $post_id, $Bbm_TagsMap_GlobalMethod);
+				if (!empty($tag_cache))
+				{
+					foreach($tag_cache as $tag)
+					{
+						$this->_bbCodesMap[$tag][] = $post_id;
+					}
+					$has_loaded_tags = true;
+				}
+			}
+			$time = microtime(true);
 			if($Bbm_TagsMap_GlobalMethod)
 			{
-                if (!$has_loaded_tags)
-                {
-                    //Global method => will check  all the elements (if they are strings) of the post array
-                    $flattenPostIt = new RecursiveIteratorIterator( new RecursiveArrayIterator($data) );
-                    $allPostItemsInOne = '';
+				if (!$has_loaded_tags)
+				{
+					//Global method => will check  all the elements (if they are strings) of the post array
+					$flattenPostIt = new RecursiveIteratorIterator( new RecursiveArrayIterator($data) );
+					$allPostItemsInOne = '';
 
-                    foreach ($flattenPostIt as $postItem)
-                    {
-                        if(is_string($postItem))
-                        {
-                            $allPostItemsInOne .= '#&#' . $postItem;
-                        }
-                    }
+					foreach ($flattenPostIt as $postItem)
+					{
+						if(is_string($postItem))
+						{
+							$allPostItemsInOne .= '#&#' . $postItem;
+						}
+					}
 
-                    $target = $allPostItemsInOne;
-                    $this->_tagBBCodeFromTree($cache_enabled, $tag_cache, $post_id, $this->getParser()->parse($target) );
-                }
+					$target = $allPostItemsInOne;
+					$this->_tagBBCodeFromTree($cache_enabled, $tag_cache, $post_id, $this->getParser()->parse($target) );
+				}
 			}
 			else
 			{
 				//Restrictive method => will only check the message & signature elements of the post array
-                if (!$has_loaded_tags)
-                {
-                    $BbCodesTree = null;
+				if (!$has_loaded_tags)
+				{
+					$BbCodesTree = null;
 
-                    if (isset($data[$parsedMessageKey]))
-                    {
-                        $BbCodesTree = @unserialize($data[$parsedMessageKey]);
-                    }
+					if (isset($data[$parsedMessageKey]))
+					{
+						$BbCodesTree = @unserialize($data[$parsedMessageKey]);
+					}
 
-                    if (!$BbCodesTree)
-                    {
-                        $target = $data[$messageKey];
-                        $BbCodesTree = $this->getParser()->parse($target);
-                    }
-                    $this->_tagBBCodeFromTree(!$has_loaded_tags && $cache_enabled, $tag_cache, $post_id, $BbCodesTree );
-                }
-                
+					if (!$BbCodesTree)
+					{
+						$target = $data[$messageKey];
+						$BbCodesTree = $this->getParser()->parse($target);
+					}
+					$this->_tagBBCodeFromTree(!$has_loaded_tags && $cache_enabled, $tag_cache, $post_id, $BbCodesTree );
+				}
+
 				// extra data should be relatively small, don't do tag map caching. This also ensures cache invalidation stays sane
 				foreach($extraKeys as $extrakey)
 				{
@@ -1979,7 +1979,7 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 					{
 						continue;
 					}
-					
+
 					$BbCodesTree = null;
 					$extraparsedkey = $extrakey . $parsedKeySuffix;
 
@@ -1988,20 +1988,20 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 					{
 						$BbCodesTree = @unserialize($data[$extraparsedkey]);
 					}
-                        
+
 					if ($BbCodesTree == null)
 					{
 						$target = $data[$extrakey];
 						$BbCodesTree = $this->getParser()->parse($target);
 					}
-					
-                    $tmp = array();
+
+					$tmp = array();
 					$this->_tagBBCodeFromTree(false, $tmp, $post_id, $BbCodesTree );
 				}
 			}
 
-            if (!$has_loaded_tags && $cache_enabled && (microtime(true) - $time)*1000 > $cache_threshold)
-                $bbcodesModel->setBbCodeTagCache($content_type, $post_id, $tag_cache);            
+			if (!$has_loaded_tags && $cache_enabled && (microtime(true) - $time)*1000 > $cache_threshold)
+				$bbcodesModel->setBbCodeTagCache($content_type, $post_id, $tag_cache);            
 		}
 
 		if(self::$debug === true)

--- a/upload/library/BBM/BbCode/Formatter/Base.php
+++ b/upload/library/BBM/BbCode/Formatter/Base.php
@@ -1662,7 +1662,7 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 				$this->_threadParams = $params['thread'];
 				$this->_postsDatas = $params['posts'];
 
-				$this->_createBbCodesMap($this->_postsDatas);			
+				$this->_createBbCodesMap($this->_postsDatas, 'post');
 			}
 
 			/**
@@ -1684,7 +1684,7 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 					'conversation_id'  => 'post_id'
 				);
 				
-				$this->_createBbCodesMap($this->_postsDatas);			
+				$this->_createBbCodesMap($this->_postsDatas);
 			}
 
 			/**
@@ -1877,21 +1877,24 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 			$this->_currentPostParams[$keyValue] = $values[$keyValue];
 		}
 	}
-
-	protected function _createBbCodesMap($posts = NULL)
+    
+	protected function _createBbCodesMap($posts = NULL, $content_type = NULL)
 	{
 		if( $posts === NULL || !is_array($posts) )
 		{
 			return;
 		}
 
+        $bbcodesModel = $this->_getBbCodesModel();
 		$options = XenForo_Application::get('options');
 		$Bbm_TagsMap_GlobalMethod = $options->Bbm_TagsMap_GlobalMethod;
 		$messageKey =  $this->_bbmMessageKey;
 		$extraKeys =  $this->_bbmExtraKeys;
 		$parsedKeySuffix = $this->_bbmPostfixParsedKey;
 		$parsedMessageKey = $messageKey . $parsedKeySuffix;
-		
+        $cache_threshold = $options->Bbm_TagsMap_Cache_Threshold; // in milliseconds
+		$cache_enabled = $options->Bbm_TagsMap_Cache_Enabled && ($content_type != '');
+        
 		foreach($posts as $post_id => $post)
 		{
 			if(!empty($this->_bbmViewParamsTargetedKey))
@@ -1914,41 +1917,62 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 				continue;
 			}
 			
+            $tag_cache = array();
+            $has_loaded_tags = false;
+            if ($cache_enabled)
+            {
+                $tag_cache = $bbcodesModel->getBbCodeTagCache($content_type, $post_id, $Bbm_TagsMap_GlobalMethod);
+                if (!empty($tag_cache))
+                {
+                    foreach($tag_cache as $tag)
+                    {
+                        $this->_bbCodesMap[$tag][] = $post_id;
+                    }
+                    $has_loaded_tags = true;
+                }
+            }
+            $time = microtime(true);
 			if($Bbm_TagsMap_GlobalMethod)
 			{
-				//Global method => will check  all the elements (if they are strings) of the post array
-				$flattenPostIt = new RecursiveIteratorIterator( new RecursiveArrayIterator($data) );
-				$allPostItemsInOne = '';
+                if (!$has_loaded_tags)
+                {
+                    //Global method => will check  all the elements (if they are strings) of the post array
+                    $flattenPostIt = new RecursiveIteratorIterator( new RecursiveArrayIterator($data) );
+                    $allPostItemsInOne = '';
 
-				foreach ($flattenPostIt as $postItem)
-				{
-					if(is_string($postItem))
-					{
-						$allPostItemsInOne .= '#&#' . $postItem;				
-					}
-				}
+                    foreach ($flattenPostIt as $postItem)
+                    {
+                        if(is_string($postItem))
+                        {
+                            $allPostItemsInOne .= '#&#' . $postItem;
+                        }
+                    }
 
-				$target = $allPostItemsInOne;
-				$this->_tagBBCodeFromTree( $post_id, $this->getParser()->parse($target) );
+                    $target = $allPostItemsInOne;
+                    $this->_tagBBCodeFromTree($cache_enabled, $tag_cache, $post_id, $this->getParser()->parse($target) );
+                }
 			}
 			else
 			{
 				//Restrictive method => will only check the message & signature elements of the post array
-				$BbCodesTree = null;
+                if (!$has_loaded_tags)
+                {
+                    $BbCodesTree = null;
 
-				if (isset($data[$parsedMessageKey]))
-				{
-					$BbCodesTree = @unserialize($data[$parsedMessageKey]);
-				}
+                    if (isset($data[$parsedMessageKey]))
+                    {
+                        $BbCodesTree = @unserialize($data[$parsedMessageKey]);
+                    }
 
-				if (!$BbCodesTree)
-				{
-					$target = $data[$messageKey];
-					$BbCodesTree = $this->getParser()->parse($target);
-				}
-				
-				$this->_tagBBCodeFromTree( $post_id, $BbCodesTree );
-				
+                    if (!$BbCodesTree)
+                    {
+                        $target = $data[$messageKey];
+                        $BbCodesTree = $this->getParser()->parse($target);
+                    }
+                    $this->_tagBBCodeFromTree(!$has_loaded_tags && $cache_enabled, $tag_cache, $post_id, $BbCodesTree );
+                }
+                
+				// extra data should be relatively small, don't do tag map caching. This also ensures cache invalidation stays sane
 				foreach($extraKeys as $extrakey)
 				{
 					if(!isset($data[$extrakey]) || !is_string($data[$extrakey]))
@@ -1971,9 +1995,13 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 						$BbCodesTree = $this->getParser()->parse($target);
 					}
 					
-					$this->_tagBBCodeFromTree( $post_id, $BbCodesTree );
+                    $tmp = array();
+					$this->_tagBBCodeFromTree(false, $tmp, $post_id, $BbCodesTree );
 				}
 			}
+
+            if (!$has_loaded_tags && $cache_enabled && (microtime(true) - $time)*1000 > $cache_threshold)
+                $bbcodesModel->setBbCodeTagCache($content_type, $post_id, $tag_cache);            
 		}
 
 		if(self::$debug === true)
@@ -1982,8 +2010,8 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 			Zend_Debug::dump($this->_bbCodesMap);
 		}
 	}
-
-	protected function _tagBBCodeFromTree($post_id, $BbCodesTree)
+    
+	protected function _tagBBCodeFromTree($canCacheTagMap, array &$tagMapCache, $post_id, $BbCodesTree)
 	{
 		if(!is_array($BbCodesTree))
 		{
@@ -1994,11 +2022,14 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 		{
 			if (isset($entry['tag']))
 			{
-				$this->_bbCodesMap[$entry['tag']][] = $post_id;
+                $tag = $entry['tag'];
+				$this->_bbCodesMap[$tag][] = $post_id;
+                if ($canCacheTagMap)
+                    $tagMapCache[] = $tag;
 
 				if (!empty($entry['children']))
 				{
-					$this->_tagBBCodeFromTree($post_id, $entry['children']);
+					$this->_tagBBCodeFromTree($canCacheTagMap, $tagMapCache, $post_id, $entry['children']);
 				}
 			}
 		}
@@ -2285,5 +2316,16 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 	{
 		return $this->bbmGetTemplateParam('viewName');
 	}			
+
+    static $BbCodesModel = null;
+    
+    protected function _getBbCodesModel()
+    {
+        if (self::$BbCodesModel == null)
+        {
+            self::$BbCodesModel = XenForo_Model::Create('BBM_Model_BbCodes');
+        }
+        return self::$BbCodesModel;
+    }
 }
 //Zend_Debug::dump($abc);

--- a/upload/library/BBM/DataWriter/Post.php
+++ b/upload/library/BBM/DataWriter/Post.php
@@ -2,38 +2,38 @@
 
 class BBM_DataWriter_Post extends XFCP_BBM_DataWriter_Post
 {
-    static $BbCodesModel = null;
-    
-    protected function _getBbCodesModel()
-    {
-        if (self::$BbCodesModel === null)
-        {
-            self::$BbCodesModel = XenForo_Model::Create('BBM_Model_BbCodes');
-        }
-        return self::$BbCodesModel;
-    }
-    
-    protected function _InvalidateCaches()
-    {
-        self::_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), array());    
-    }
+	static $BbCodesModel = null;
+
+	protected function _getBbCodesModel()
+	{
+		if (self::$BbCodesModel === null)
+		{
+			self::$BbCodesModel = XenForo_Model::Create('BBM_Model_BbCodes');
+		}
+		return self::$BbCodesModel;
+	}
+
+	protected function _InvalidateCaches()
+	{
+		self::_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), array());    
+	}
 
 	protected function _postSaveAfterTransaction()
 	{
-        parent::_postSaveAfterTransaction();
-        if ($this->isUpdate())
-        {
-            if ($this->isChanged('message') || ($this->isChanged('message_state') && $this->get('message_state') == 'deleted'))
-            {
-                $this->_InvalidateCaches();
-            }
-        }
-    }
-    
+		parent::_postSaveAfterTransaction();
+		if ($this->isUpdate())
+		{
+			if ($this->isChanged('message') || ($this->isChanged('message_state') && $this->get('message_state') == 'deleted'))
+			{
+				$this->_InvalidateCaches();
+			}
+		}
+	}
+
 	protected function _messagePostDelete()
 	{
-        parent::_messagePostDelete();
-        $this->_InvalidateCaches();
-    }    
-    
+		parent::_messagePostDelete();
+		$this->_InvalidateCaches();
+	}
+
 }

--- a/upload/library/BBM/DataWriter/Post.php
+++ b/upload/library/BBM/DataWriter/Post.php
@@ -1,0 +1,39 @@
+<?php
+
+class BBM_DataWriter_Post extends XFCP_BBM_DataWriter_Post
+{
+    static $BbCodesModel = null;
+    
+    protected function _getBbCodesModel()
+    {
+        if (self::$BbCodesModel === null)
+        {
+            self::$BbCodesModel = XenForo_Model::Create('BBM_Model_BbCodes');
+        }
+        return self::$BbCodesModel;
+    }
+    
+    protected function _InvalidateCaches()
+    {
+        self::_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), array());    
+    }
+
+	protected function _postSaveAfterTransaction()
+	{
+        parent::_postSaveAfterTransaction();
+        if ($this->isUpdate())
+        {
+            if ($this->isChanged('message') || ($this->isChanged('message_state') && $this->get('message_state') == 'deleted'))
+            {
+                $this->_InvalidateCaches();
+            }
+        }
+    }
+    
+	protected function _messagePostDelete()
+	{
+        parent::_messagePostDelete();
+        $this->_InvalidateCaches();
+    }    
+    
+}

--- a/upload/library/BBM/DataWriter/Post.php
+++ b/upload/library/BBM/DataWriter/Post.php
@@ -2,20 +2,20 @@
 
 class BBM_DataWriter_Post extends XFCP_BBM_DataWriter_Post
 {
-	static $BbCodesModel = null;
+	protected $BbCodesModel = null;
 
 	protected function _getBbCodesModel()
 	{
-		if (self::$BbCodesModel === null)
+		if ($this->BbCodesModel === null)
 		{
-			self::$BbCodesModel = XenForo_Model::Create('BBM_Model_BbCodes');
+			$this->BbCodesModel = XenForo_Model::Create('BBM_Model_BbCodes');
 		}
-		return self::$BbCodesModel;
+		return $this->BbCodesModel;
 	}
 
 	protected function _InvalidateCaches()
 	{
-		self::_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), array());    
+		$this->_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), array());    
 	}
 
 	protected function _postSaveAfterTransaction()

--- a/upload/library/BBM/Listeners/AllInOne.php
+++ b/upload/library/BBM/Listeners/AllInOne.php
@@ -41,6 +41,10 @@ class BBM_Listeners_AllInOne
 				case 'XenForo_ControllerPublic_Help':
 					$extend[] = 'BBM_ControllerPublic_Help';				
 				break;
+
+				case 'XenForo_DataWriter_DiscussionMessage_Post':
+					$extend[] = 'BBM_DataWriter_Post';
+				break;
 			}
 		}
 	}

--- a/upload/library/BBM/Model/BbCodes.php
+++ b/upload/library/BBM/Model/BbCodes.php
@@ -657,31 +657,31 @@ class BBM_Model_BbCodes extends XenForo_Model
 		return $document;
 	}
     
-	static $cacheObject;
-	static $TagMapCacheOptions = null;
+	protected $cacheObject = null;
+	protected $TagMapCacheOptions = null;
 
 	protected function _getTagMapCacheOptions()
 	{
-		if (self::$TagMapCacheOptions === null)
+		if ($this->TagMapCacheOptions === null)
 		{
 			$options = XenForo_Application::get('options');
-			self::$TagMapCacheOptions = array(
+			$this->TagMapCacheOptions = array(
 				'GlobalMethod' => $options->Bbm_TagsMap_GlobalMethod,
 				'Expiry'       => $options->Bbm_TagsMap_Cache_Expiry,
 				'EnableCache'  => $options->Bbm_TagsMap_Cache_Enabled,
 				'bbCodeCacheVersion'  => $options->bbCodeCacheVersion
 				);
 		}   
-		return self::$TagMapCacheOptions;
+		return $this->TagMapCacheOptions;
 	}
 
 	public function getBbCodeTagCache($content_type, $post_id)
 	{ 
-		if (!isset(self::$cacheObject))
+		if ($this->cacheObject === null)
 		{
-			self::$cacheObject = XenForo_Application::getCache();
+			$this->cacheObject = XenForo_Application::getCache();
 		}
-		if (self::$cacheObject !== false)
+		if ($this->cacheObject !== false)
 		{
 			$options = $this->_getTagMapCacheOptions();
 
@@ -690,7 +690,7 @@ class BBM_Model_BbCodes extends XenForo_Model
 						$options['bbCodeCacheVersion'] . 
 						($options['GlobalMethod'] ? "1" : "0")
 						;
-			if ($raw = self::$cacheObject->load($cacheId, true))
+			if ($raw = $this->cacheObject->load($cacheId, true))
 			{
 				return explode(',', $raw);
 			}
@@ -700,12 +700,12 @@ class BBM_Model_BbCodes extends XenForo_Model
 
 	public function setBbCodeTagCache($content_type, $post_id, array $tagMapCache)
 	{  
-		if (!isset(self::$cacheObject))
+		if ($this->cacheObject === null)
 		{
-			self::$cacheObject = XenForo_Application::getCache();
+			$this->cacheObject = XenForo_Application::getCache();
 		}
 
-		if (self::$cacheObject)
+		if ($this->cacheObject)
 		{
 			$options = $this->_getTagMapCacheOptions();
 
@@ -717,12 +717,13 @@ class BBM_Model_BbCodes extends XenForo_Model
 			if (!empty($tagMapCache) && $options['EnableCache'])
 			{
 				$data = implode(',', $tagMapCache);
+                $this->cacheObject->save($data, $cacheId, array(), $options['Expiry']);
 			}
 			else
 			{
 				$data = false;
+                $this->cacheObject->remove($data);
 			}
-			self::$cacheObject->save($data, $cacheId, array(), $options['Expiry']);
 		}
 	}
 }

--- a/upload/library/BBM/Model/BbCodes.php
+++ b/upload/library/BBM/Model/BbCodes.php
@@ -657,73 +657,73 @@ class BBM_Model_BbCodes extends XenForo_Model
 		return $document;
 	}
     
-    static $cacheObject;
-    static $TagMapCacheOptions = null;
-    
-    protected function _getTagMapCacheOptions()
-    {
-        if (self::$TagMapCacheOptions === null)
-        {
-            $options = XenForo_Application::get('options');
-            self::$TagMapCacheOptions = array(
-                'GlobalMethod' => $options->Bbm_TagsMap_GlobalMethod,
-                'Expiry'       => $options->Bbm_TagsMap_Cache_Expiry,
-                'EnableCache'  => $options->Bbm_TagsMap_Cache_Enabled,
-                'bbCodeCacheVersion'  => $options->bbCodeCacheVersion
-            );
-        }   
-        return self::$TagMapCacheOptions;
-    }
-    
-    public function getBbCodeTagCache($content_type, $post_id)
-    { 
-        if (!isset(self::$cacheObject))
-        {
-            self::$cacheObject = XenForo_Application::getCache();
-        }
+	static $cacheObject;
+	static $TagMapCacheOptions = null;
+
+	protected function _getTagMapCacheOptions()
+	{
+		if (self::$TagMapCacheOptions === null)
+		{
+			$options = XenForo_Application::get('options');
+			self::$TagMapCacheOptions = array(
+				'GlobalMethod' => $options->Bbm_TagsMap_GlobalMethod,
+				'Expiry'       => $options->Bbm_TagsMap_Cache_Expiry,
+				'EnableCache'  => $options->Bbm_TagsMap_Cache_Enabled,
+				'bbCodeCacheVersion'  => $options->bbCodeCacheVersion
+				);
+		}   
+		return self::$TagMapCacheOptions;
+	}
+
+	public function getBbCodeTagCache($content_type, $post_id)
+	{ 
+		if (!isset(self::$cacheObject))
+		{
+			self::$cacheObject = XenForo_Application::getCache();
+		}
 		if (self::$cacheObject !== false)
 		{
-            $options = $this->_getTagMapCacheOptions();
+			$options = $this->_getTagMapCacheOptions();
 
-            $cacheId = $content_type . 
-                       $post_id. 
-                       $options['bbCodeCacheVersion'] . 
-                       ($options['GlobalMethod'] ? "1" : "0")
-                       ;
+			$cacheId = $content_type . 
+						$post_id. 
+						$options['bbCodeCacheVersion'] . 
+						($options['GlobalMethod'] ? "1" : "0")
+						;
 			if ($raw = self::$cacheObject->load($cacheId, true))
 			{
 				return explode(',', $raw);
 			}
 		}   
-        return array();
-    }    
-    
-    public function setBbCodeTagCache($content_type, $post_id, array $tagMapCache)
-    {  
-        if (!isset(self::$cacheObject))
-        {
-            self::$cacheObject = XenForo_Application::getCache();
-        }
+		return array();
+	}    
 
-        if (self::$cacheObject)
-        {
-            $options = $this->_getTagMapCacheOptions();
+	public function setBbCodeTagCache($content_type, $post_id, array $tagMapCache)
+	{  
+		if (!isset(self::$cacheObject))
+		{
+			self::$cacheObject = XenForo_Application::getCache();
+		}
 
-            $cacheId = $content_type . 
-                       $post_id. 
-                       $options['bbCodeCacheVersion'] . 
-                       ($options['GlobalMethod'] ? "1" : "0")
-                       ;
-            if (!empty($tagMapCache) && $options['EnableCache'])
-            {
-                $data = implode(',', $tagMapCache);
-            }
-            else
-            {
-                $data = false;
-            }
+		if (self::$cacheObject)
+		{
+			$options = $this->_getTagMapCacheOptions();
+
+			$cacheId = $content_type . 
+						$post_id. 
+						$options['bbCodeCacheVersion'] . 
+						($options['GlobalMethod'] ? "1" : "0")
+						;
+			if (!empty($tagMapCache) && $options['EnableCache'])
+			{
+				$data = implode(',', $tagMapCache);
+			}
+			else
+			{
+				$data = false;
+			}
 			self::$cacheObject->save($data, $cacheId, array(), $options['Expiry']);
 		}
-    }
+	}
 }
 //Zend_Debug::dump($code);


### PR DESCRIPTION
Implements tag map caching based off duration of the last unserialize/parse/tag map build.

Discovered a class of threads which where causing createBbCodesMap to take anywhere upto 250ms to execute due to unserialize performance and the number of entries to parse over.

Default is to only cache if handling a post takes longer than ~5ms, for 1 week via the defined XenForo cache method. Uses bbcode versioning to determine if it should ignore all the old keys.

A few configurables added into BBM's options panel.

This pull request is implicitly dependant on this pull request, https://github.com/cclaerhout/xen_BBM_v2/pull/6 due to the usage of listener event hints.

