### PR TITLE
Improve compatibility during upgrade for missing bbcode attributes.

### DIFF
--- a/upload/library/BBM/BbCode/Formatter/Base.php
+++ b/upload/library/BBM/BbCode/Formatter/Base.php
@@ -167,7 +167,7 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
       				$allBbmTags[$tagName]['stopLineBreakConversion'] = true;
       			}
 
-      			if($bbm['trimContent'])
+      			if(!empty($bbm['trimContent']))
       			{
       				$allBbmTags[$tagName]['trimContent'] = true;
       			}


### PR DESCRIPTION
On upgrading to latest version of BBM with 'trimContent', the error log was flooded with messages about 'trimContent' missing.

This was due to a lag between deploying the files and running the upgrade process.

Using "!empty()" when adding new items in bakeBbmTags prevents these errors from occurring.