### PR TITLE
Fix "Redefinition of parameter" error which is now forbidden in php7

### DIFF
--- a/upload/library/BBM/Listeners/AllInOne.php
+++ b/upload/library/BBM/Listeners/AllInOne.php
@@ -171,7 +171,7 @@ class BBM_Listeners_AllInOne
 		 	{
 		 		foreach($buttonGroup as $key => $button)
 		 		{
-		 			if(!self::filterButton($button, $editorOptions, $editorOptions, $showWysiwyg))
+		 			if(!self::filterButton($button, $editorOptions, $showWysiwyg))
 		 			{
 		 				unset($buttonGroup[$key]);
 		 				continue;
@@ -193,7 +193,7 @@ class BBM_Listeners_AllInOne
 			{
 	 			$customTag = "custom_$k";
 
-	 			if(!in_array($customTag, $allGridButtons) && self::filterButton($customTag, $editorOptions, $editorOptions, $showWysiwyg))
+	 			if(!in_array($customTag, $allGridButtons) && self::filterButton($customTag, $editorOptions, $showWysiwyg))
 	 			{
 	 				$customBbCodesButtons[] = $customTag;
 	 			}
@@ -368,7 +368,7 @@ class BBM_Listeners_AllInOne
 		}
 	}
 
-	public static function filterButton($button, $editorOptions, array $editorOptions, $showWysiwyg)
+	public static function filterButton($button, array $editorOptions, $showWysiwyg)
 	{
 		if($button == 'draft' && empty($editorOptions['autoSaveUrl']))
 		{


### PR DESCRIPTION
Addresses the php7 compatibility issue reported here: https://xenforo.com/community/threads/bbcodes-buttons-manager.48898/page-45#post-968357

ref: https://wiki.php.net/phpng
###### Incompatibilities (made on purpose and are not going to be fixed) 
- Function parameters with duplicate name are not allowed anymore. Definitions like “function foo($x,$x) {}” will lead to compile time error “Redefinition of parameter”