### PR TITLE
Pre caching tweaks

### DIFF
--- a/upload/library/BBM/BbCode/Formatter/Base.php
+++ b/upload/library/BBM/BbCode/Formatter/Base.php
@@ -100,8 +100,6 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
     	  				$allBbmTags[$tagName]['phpcallback_method'] = $bbm['phpcallback_method'];
     	  				$allBbmTags[$tagName]['callback'] = array($this, 'PhpMethodRenderer');
 
-      					$this->_prepareClassToLoad($bbm['phpcallback_class']);
-
     	  				if($bbm['plainCallback'])
     	  				{
     	  					$allBbmTags[$tagName]['parseCallback'] = array($this, 'parseValidatePlainIfNoOption');
@@ -127,7 +125,6 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
     		  				$allBbmTags[$tagName]['template_callback']['class'] = $bbm['template_callback_class'];
     		  				$allBbmTags[$tagName]['template_callback']['method'] = $bbm['template_callback_method'];
 
-    	  					$this->_prepareClassToLoad($bbm['template_callback_class']);
     	  					$this->_preLoadTemplatesFromCallback($bbm['template_callback_class'], $bbm['template_callback_method']);
     	  				}
     	  				else
@@ -342,8 +339,6 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 			
 			$this->_xenWrappersCallback['class'] = $xenWrapperCallback['class'];
 			$this->_xenWrappersCallback['method'] = $xenWrapperCallback['method'];
-
-			$this->_prepareClassToLoad($xenWrapperCallback['class']);
 		}
 		
 		if(!empty($options->Bbm_PreCache_XenTags))
@@ -413,30 +408,6 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 	public function preParserEnableFor($tagName)
 	{
 		return isset($this->_bbmPreParserBbCodes[$tagName]);
-	}
-
-	/****
-	*	CLASS LOADER TOOLS
-	*	Reason: no need to load class several times
-	***/
-	protected $_classToLoad = array();
-	
-	protected function _prepareClassToLoad($class)
-	{
-		if(!in_array($class, $this->_classToLoad))
-		{
-			$this->_classToLoad[] = $class;
-		}
-	}
-	
-	protected function _loadClass($class)
-	{
-		if(in_array($class, $this->_classToLoad))
-		{
-			XenForo_Application::autoload($class);
-			$key = array_search($class, $this->_classToLoad);
-			unset($this->_classToLoad[$key]);
-		}		
 	}
 
 	/****
@@ -607,8 +578,6 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 		{
 			$template_callback_class = $tagInfo['template_callback']['class'];
 			$template_callback_method = $tagInfo['template_callback']['method'];
-		
-			$this->_loadClass($template_callback_class);
 
 			if(method_exists($template_callback_class, '__construct'))
 			{
@@ -693,8 +662,6 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 		
 		$phpcallback_class = $tagInfo['phpcallback_class'];
 		$phpcallback_method = $tagInfo['phpcallback_method'];
-
-		$this->_loadClass($phpcallback_class);
 
 		return $this->bbmMethodOutputFilter(
 			call_user_func_array(array($phpcallback_class, $phpcallback_method), array($tag, $rendererStates, &$this)),
@@ -885,7 +852,6 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
       		//Bbm Tag Wrapping option
       		if($this->_xenWrappersCallback && in_array($tag['tag'], $this->_xenOriginalTags))
       		{
-			$this->_loadClass($this->_xenWrappersCallback['class']);
 			call_user_func_array(array($this->_xenWrappersCallback['class'], $this->_xenWrappersCallback['method']), array($tag, $this));
       		}
 

--- a/upload/library/BBM/BbCode/Formatter/Extensions/PreCacheBase.php
+++ b/upload/library/BBM/BbCode/Formatter/Extensions/PreCacheBase.php
@@ -66,6 +66,32 @@ class BBM_BbCode_Formatter_Extensions_PreCacheBase extends XFCP_BBM_BbCode_Forma
 		return parent::renderTree($tree, $extraStates);
 	}
 
+    protected $bbm_preCache_tags = null;
+    
+	protected function _getOriginalTagRule($tagName)
+	{
+		$tagName = strtolower($tagName);
+
+		if (!empty($this->bbm_preCache_tags[$tagName]) && is_array($this->bbm_preCache_tags[$tagName]))
+		{
+			return $this->bbm_preCache_tags[$tagName];
+		}
+		else
+		{
+			return array();
+		}
+	}
+
+    //@extended
+    public function incrementTagMap(array $tagInfo, array $tag, array $rendererStates)
+    {
+        if (empty($tagInfo))
+        {
+            $tagInfo = $this->_getOriginalTagRule($tag['tag']);
+        }
+        return parent::incrementTagMap($tagInfo, $tag, $rendererStates);
+    }
+
 	//@extended
 	public function renderValidTag(array $tagInfo, array $tag, array $rendererStates)
 	{
@@ -121,8 +147,8 @@ class BBM_BbCode_Formatter_Extensions_PreCacheBase extends XFCP_BBM_BbCode_Forma
 		if ($view && XenForo_Application::get('options')->get('Bbm_PreCache_Enable'))
 		{
             // check if there are any tags with preParser enabled
-            $_tags = $this->_tags;
-            $sanitizedTags = $this->sanitizeTagsForPreParse($_tags);
+            $this->bbm_preCache_tags = $this->_tags;
+            $sanitizedTags = $this->sanitizeTagsForPreParse($this->bbm_preCache_tags);
             if (empty($sanitizedTags))
             {
                 return;
@@ -288,7 +314,7 @@ class BBM_BbCode_Formatter_Extensions_PreCacheBase extends XFCP_BBM_BbCode_Forma
             {
                 $this->renderTree($BbCodesTree, array('bbmPreCacheInit' => true));
             }
-            $this->_tags = $_tags;
+            $this->_tags = $this->bbm_preCache_tags;
             $this->_smilieTranslate = $_smilieTranslate;
             $extraStates = array();
             XenForo_CodeEvent::fire('bbm_callback_precache', array(&$this->_bbmPreCache, &$extraStates, 'base'));

--- a/upload/library/BBM/BbCode/Formatter/Extensions/PreCacheBase.php
+++ b/upload/library/BBM/BbCode/Formatter/Extensions/PreCacheBase.php
@@ -6,7 +6,6 @@ class BBM_BbCode_Formatter_Extensions_PreCacheBase extends XFCP_BBM_BbCode_Forma
 	***/
 	protected $_bbmTextView = '';
 	
-	protected $_bbmPreCacheActive = false;
 	protected $_bbmPreCache = array();
 
 	public function getBbmPreCache()
@@ -46,36 +45,23 @@ class BBM_BbCode_Formatter_Extensions_PreCacheBase extends XFCP_BBM_BbCode_Forma
 		}
 	}
 
-	protected $_bbmPreCacheDone = false;
+    protected $bbm_preCache_base = null;
 
 	//@extended
 	public function renderTree(array $tree, array $extraStates = array())
 	{
-		if(XenForo_Application::get('options')->get('Bbm_PreCache_Enable'))
-		{
-			if(!empty($extraStates['bbmPreCacheInit']) && !$this->_bbmPreCacheDone)
-			{
-				parent::renderTree($tree, $extraStates);
-				unset($extraStates['bbmPreCacheInit']);
-				
-				XenForo_CodeEvent::fire('bbm_callback_precache', array(&$this->_bbmPreCache, &$extraStates, 'base'));
-				XenForo_Application::set('bbm_preCache_base', array($this->_bbmPreCache, $extraStates));
-
-				$this->_bbmPreCacheDone = true;
-
-				/*Bb Codes MAP*/
-				$this->_resetIncrementation();
-				return '';
-			}
-
-			if (XenForo_Application::isRegistered('bbm_preCache_base'))
-			{
-				list($_bbmPreCache, $_extraStates) = XenForo_Application::get('bbm_preCache_base');
-				$this->_bbmPreCache = $_bbmPreCache;
-				$extraStates['bbmPreCacheComplete'] = true;
-				$extraStates += $_extraStates;
-			}
-		}
+        if(!empty($extraStates['bbmPreCacheInit']))
+        {
+            parent::renderTree($tree, $extraStates);
+            return '';
+        }
+        else if ($this->bbm_preCache_base !== null)
+        {
+            list($_bbmPreCache, $_extraStates) = $this->bbm_preCache_base;
+            $this->_bbmPreCache = $_bbmPreCache;
+            $extraStates['bbmPreCacheComplete'] = true;
+            $extraStates += $_extraStates;
+        }
 
 		return parent::renderTree($tree, $extraStates);
 	}
@@ -85,25 +71,63 @@ class BBM_BbCode_Formatter_Extensions_PreCacheBase extends XFCP_BBM_BbCode_Forma
 	{
 		//Need to call the parent in both cases - reason: the bbm post params management is done trough this function
 		$parent = parent::renderValidTag($tagInfo, $tag, $rendererStates);
-		$tagName = $tag['tag'];
 
-		if(!empty($rendererStates['bbmPreCacheInit']) && !$this->preParserEnableFor($tagName) )
-		{
-			return '';
-		}
-		else
+		if(empty($rendererStates['bbmPreCacheInit']))
 		{
 			return $parent;
 		}
+		return '';
 	}
+
+    //@extended
+    public function renderString($string, array $rendererStates, &$trimLeadingLines)
+    {
+        if(empty($rendererStates['bbmPreCacheInit']))
+        {
+            return parent::renderString($string, $rendererStates, $trimLeadingLines);
+        }
+        return '';
+    }
+
+    //@extended
+    public function renderTagUnparsed(array $tag, array $rendererStates)
+    {
+        if(empty($rendererStates['bbmPreCacheInit']))
+        {
+            return parent::renderTagUnparsed($tag, $rendererStates);
+        }
+        $this->renderSubTree($tag['children'], $rendererStates);
+        return '';
+    }
+
+    protected function sanitizeTagsForPreParse(array $tags)
+    {
+        foreach($tags as $tagName => &$tag)
+        {
+            if (!$this->preParserEnableFor($tagName))
+            {
+                unset($tags[$tagName]);
+            }
+        }
+        return $tags;
+    }
 	
 	//@extended
 	public function setView(XenForo_View $view = null)
 	{
+		$this->_cacheBbcodeTree = true;
 		parent::setView($view);
 
 		if ($view && XenForo_Application::get('options')->get('Bbm_PreCache_Enable'))
 		{
+            // check if there are any tags with preParser enabled
+            $_tags = $this->_tags;
+            $sanitizedTags = $this->sanitizeTagsForPreParse($_tags);
+            if (empty($sanitizedTags))
+            {
+                return;
+            }
+
 			/**
 			 * Purpose: get back the original text and parse it will a special rendererState
 			 * It will manage inside the renderTree function (global init), then in the 
@@ -216,49 +240,62 @@ class BBM_BbCode_Formatter_Extensions_PreCacheBase extends XFCP_BBM_BbCode_Forma
 				}
 			}
 
+			$trees = array();
+			$parser = $this->getParser();
 			if(!empty($data))
 			{
 				if(!is_array($data))
 				{
 					$data = array($data);
 				}
+                
+                $parsedKeySuffix = $this->_bbmPostfixParsedKey;
+                
+                foreach($data as $key => $data)
+                {
+                    foreach($keys as $index)
+                    {
+                        if(!isset($data[$index]) || !is_string($data[$index]))
+                        {
+                            continue;
+                        }
 
-				if(!$multiMode)
-				{
-					foreach($data as $key => $value)
-					{
-						if(!in_array($key, $keys) || !is_string($value))
-						{
-							continue;
-						}
-					
-						$text .= $value;
-					}
-				}
-				else
-				{
-					foreach($data as $multi)
-					{
-						foreach($multi as $key => $value)
-						{
-							if(!in_array($key, $keys) || !is_string($value))
-							{
-								continue;
-							}
-						
-							$text .= $value;
-						}					
-					}
-				}
+                        $BbCodesTree = null;
+                        if (isset($this->_parseCache[$key.$index]))
+                        {
+                            $BbCodesTree = $this->_parseCache[$key.$index];
+                        }
+
+                        if (!$BbCodesTree && isset($data[$index . $parsedKeySuffix]))
+                        {
+                            $BbCodesTree = @unserialize($data[$index . $parsedKeySuffix]);
+                        }
+
+                        if (!$BbCodesTree)
+                        {
+                            $BbCodesTree = $parser->parse($data[$index]);
+                        }
+                        $trees[] = $BbCodesTree;
+                    }
+                }
 			}
 
-			$this->_bbmTextView = $text;
-			
-			if(!empty($text))
-			{
-				$parser = $this->getParser();
-				$parser->render($text, array('bbmPreCacheInit' => true));
-			}
+            // optimize a bunch of known bbcodes to be near no-ops
+            $this->_tags = $sanitizedTags;
+            $_smilieTranslate = $this->_smilieTranslate;
+            $this->_smilieTranslate = array();
+            foreach($trees as $BbCodesTree)
+            {
+                $this->renderTree($BbCodesTree, array('bbmPreCacheInit' => true));
+            }
+            $this->_tags = $_tags;
+            $this->_smilieTranslate = $_smilieTranslate;
+            $extraStates = array();
+            XenForo_CodeEvent::fire('bbm_callback_precache', array(&$this->_bbmPreCache, &$extraStates, 'base'));
+            $this->bbm_preCache_base = array($this->_bbmPreCache, $extraStates);
+
+            /*Bb Codes MAP*/
+            $this->_resetIncrementation();
 		}
 	}	
 }

--- a/upload/library/BBM/BbCode/Formatter/Extensions/PreCacheWysiwyg.php
+++ b/upload/library/BBM/BbCode/Formatter/Extensions/PreCacheWysiwyg.php
@@ -6,7 +6,6 @@ class BBM_BbCode_Formatter_Extensions_PreCacheWysiwyg extends XFCP_BBM_BbCode_Fo
 	***/
 	protected $_bbmTextView = '';
 	
-	protected $_bbmPreCacheActive = false;
 	protected $_bbmPreCache = array();
 
 	public function getBbmPreCache()
@@ -46,35 +45,25 @@ class BBM_BbCode_Formatter_Extensions_PreCacheWysiwyg extends XFCP_BBM_BbCode_Fo
 		}
 	}
 
-	protected $_bbmPreCacheDone = false;
+    protected $bbm_preCache_base = null;
+    protected $_bbmPostfixParsedKey = '_parsed';
 
 	//@extended
 	public function renderTree(array $tree, array $extraStates = array())
 	{
-		if(XenForo_Application::get('options')->get('Bbm_PreCache_Enable'))
-		{
-			if(!empty($extraStates['bbmPreCacheInit']) && !$this->_bbmPreCacheDone)
-			{
-				parent::renderTree($tree, $extraStates);
-				unset($extraStates['bbmPreCacheInit']);
+        if(!empty($extraStates['bbmPreCacheInit']))
+        {
+            parent::renderTree($tree, $extraStates);
+            return '';
+        }
+        else if ($this->bbm_preCache_base !== null)
+        {
+            list($_bbmPreCache, $_extraStates) = $this->bbm_preCache_base;
+            $this->_bbmPreCache = $_bbmPreCache;
+            $extraStates['bbmPreCacheComplete'] = true;
+            $extraStates += $_extraStates;
+        }
 
-				XenForo_CodeEvent::fire('bbm_callback_precache', array(&$this->_bbmPreCache, &$extraStates, 'wysiwyg'));
-				XenForo_Application::set('bbm_preCache_wysiwyg', array($this->_bbmPreCache, $extraStates));
-
-				$this->_bbmPreCacheDone = true;
-
-				return '';
-			}
-
-			if (XenForo_Application::isRegistered('bbm_preCache_wysiwyg'))
-			{
-				list($_bbmPreCache, $_extraStates) = XenForo_Application::get('bbm_preCache_wysiwyg');
-				$this->_bbmPreCache = $_bbmPreCache;
-				$extraStates['bbmPreCacheComplete'] = true;
-				$extraStates += $_extraStates;
-			}
-		}
-		
 		return parent::renderTree($tree, $extraStates);
 	}
 
@@ -83,18 +72,47 @@ class BBM_BbCode_Formatter_Extensions_PreCacheWysiwyg extends XFCP_BBM_BbCode_Fo
 	{
 		//Need to call the parent in both cases - reason: the bbm post params management is done trough this function
 		$parent = parent::renderValidTag($tagInfo, $tag, $rendererStates);
-		$tagName = $tag['tag'];
-		
-		if(!empty($rendererStates['bbmPreCacheInit']) && !$this->preParserEnableFor($tagName) )
-		{
-			return '';
-		}
-		else
+
+		if(empty($rendererStates['bbmPreCacheInit']))
 		{
 			return $parent;
 		}
+		return '';
 	}
-	
+
+    //@extended
+    public function renderString($string, array $rendererStates, &$trimLeadingLines)
+    {
+        if(empty($rendererStates['bbmPreCacheInit']))
+        {
+            return parent::renderString($string, $rendererStates, $trimLeadingLines);
+        }
+        return '';
+    }
+
+    //@extended
+    public function renderTagUnparsed(array $tag, array $rendererStates)
+    {
+        if(empty($rendererStates['bbmPreCacheInit']))
+        {
+            return parent::renderTagUnparsed($tag, $rendererStates);
+        }
+        $this->renderSubTree($tag['children'], $rendererStates);
+        return '';
+    }
+
+    protected function sanitizeTagsForPreParse(array $tags)
+    {
+        foreach($tags as $tagName => &$tag)
+        {
+            if (!$this->preParserEnableFor($tagName))
+            {
+                unset($tags[$tagName]);
+            }
+        }
+        return $tags;
+    }
+
 	//@extended
 	public function setView(XenForo_View $view = null)
 	{
@@ -102,6 +120,14 @@ class BBM_BbCode_Formatter_Extensions_PreCacheWysiwyg extends XFCP_BBM_BbCode_Fo
 
 		if ($view && XenForo_Application::get('options')->get('Bbm_PreCache_Enable'))
 		{
+            // check if there are any tags with preParser enabled
+            $_tags = $this->_tags;
+            $sanitizedTags = $this->sanitizeTagsForPreParse($_tags);
+            if (empty($sanitizedTags))
+            {
+                return;
+            }
+
 			/**
 			 * Purpose: get back the original text and parse it will a special rendererState
 			 * It will manage inside the renderTree function (global init), then in the 
@@ -238,7 +264,9 @@ class BBM_BbCode_Formatter_Extensions_PreCacheWysiwyg extends XFCP_BBM_BbCode_Fo
 					}
 				}
 			}
-			
+
+			$trees = array();
+			$parser = $this->getParser();
 			if(!empty($data))
 			{
 				if(!is_array($data))
@@ -246,42 +274,42 @@ class BBM_BbCode_Formatter_Extensions_PreCacheWysiwyg extends XFCP_BBM_BbCode_Fo
 					$data = array($data);
 				}
 
-				if(!$multiMode)
-				{
-					foreach($data as $key => $value)
-					{
-						if(!in_array($key, $keys) || !is_string($value))
-						{
-							continue;
-						}
-					
-						$text .= $value;
-					}
-				}
-				else
-				{
-					foreach($data as $multi)
-					{
-						foreach($multi as $key => $value)
-						{
-							if(!in_array($key, $keys) || !is_string($value))
-							{
-								continue;
-							}
-						
-							$text .= $value;
-						}					
-					}
-				}
-			}
-			
-			$this->_bbmTextView = $text;
+                $parsedKeySuffix = $this->_bbmPostfixParsedKey;
+                
+                foreach($data as $key => $data)
+                {
+                    foreach($keys as $index)
+                    {
+                        if(!isset($data[$index]) || !is_string($data[$index]))
+                        {
+                            continue;
+                        }
 
-			if(!empty($text))
-			{
-				$parser = $this->getParser();
-				$parser->render($text, array('bbmPreCacheInit' => true));
+                        $BbCodesTree = null;
+                        if (isset($data[$index . $parsedKeySuffix]))
+                        {
+                            $BbCodesTree = @unserialize($data[$index . $parsedKeySuffix]);
+                        }
+
+                        if (!$BbCodesTree)
+                        {
+                            $BbCodesTree = $parser->parse($data[$index]);
+                        }
+                        $trees[] = $BbCodesTree;
+                    }
+                }
 			}
+
+            // optimize a bunch of known bbcodes to be near no-ops
+            $this->_tags = $sanitizedTags;
+            foreach($trees as $BbCodesTree)
+            {
+                $this->renderTree($BbCodesTree, array('bbmPreCacheInit' => true));
+            }
+            $this->_tags = $_tags;
+            $extraStates = array();
+            XenForo_CodeEvent::fire('bbm_callback_precache', array(&$this->_bbmPreCache, &$extraStates, 'wysiwyg'));
+            $this->bbm_preCache_base = array($this->_bbmPreCache, $extraStates);
 		}
 	}	
 }

--- a/upload/library/BBM/BbCode/Formatter/Wysiwyg.php
+++ b/upload/library/BBM/BbCode/Formatter/Wysiwyg.php
@@ -117,30 +117,6 @@ class BBM_BbCode_Formatter_Wysiwyg extends XFCP_BBM_BbCode_Formatter_Wysiwyg
 	}
 
 	/****
-	*	CLASS LOADER TOOLS
-	*	Reason: no need to load class several times
-	***/
-	protected $_classToLoad = array();
-	
-	protected function _prepareClassToLoad($class)
-	{
-		if(!in_array($class, $this->_classToLoad))
-		{
-			$this->_classToLoad[] = $class;
-		}
-	}
-	
-	protected function _loadClass($class)
-	{
-		if(in_array($class, $this->_classToLoad))
-		{
-			XenForo_Application::autoload($class);
-			$key = array_search($class, $this->_classToLoad);
-			unset($this->_classToLoad[$key]);
-		}		
-	}
-
-	/****
 	*	PARSER TOOLS
 	***/
 	protected $_bbmParser;


### PR DESCRIPTION
Addresses #18 and allows the pre-parser caching reuse existing bb-code trees. This offers significant performance improvements for complex examples of bb-code.

Additionally, this PR identifies (and fixe) a bug in the underlying BBM tag-tracking which did not correctly advance the tag-map state for invalid tags.