### PR TITLE
Improve tagmap cache invalidation

### DIFF
--- a/upload/library/BBM/BbCode/Formatter/Base.php
+++ b/upload/library/BBM/BbCode/Formatter/Base.php
@@ -1945,7 +1945,7 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 				$this->_threadParams = $params['thread'];
 				$this->_postsDatas = $params['posts'];
 
-				$this->_createBbCodesMap($this->_postsDatas, 'post');
+				$this->_createBbCodesMap($this->_postsDatas, 'post', 'last_edit_date');
 			}
 			/**
 			 * Preview new post/edit preview in thread or new thread
@@ -2277,7 +2277,7 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 	protected $_parseCache = array();
 	protected $_cacheBbcodeTree = false;
 
-	protected function _createBbCodesMap($posts = NULL, $content_type = NULL)
+	protected function _createBbCodesMap($posts = NULL, $content_type = NULL, $edit_date = NULL)
 	{
 		if( $posts === NULL || !is_array($posts) )
 		{
@@ -2318,9 +2318,9 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 
 			$tag_cache = array();
 			$has_loaded_tags = false;
-			if ($cache_enabled)
+			if ($cache_enabled && isset($post[$edit_date]))
 			{
-				$tag_cache = $bbcodesModel->getBbCodeTagCache($content_type, $post_id, $bbmRecursiveMode);
+				$tag_cache = $bbcodesModel->getBbCodeTagCache($content_type, $post_id, $post[$edit_date], $bbmRecursiveMode);
 				if (!empty($tag_cache))
 				{
 					foreach($tag_cache as $tag)
@@ -2414,9 +2414,9 @@ class BBM_BbCode_Formatter_Base extends XFCP_BBM_BbCode_Formatter_Base
 				}
 			}
 
-			if (!$has_loaded_tags && $cache_enabled && (microtime(true) - $time)*1000 > $cache_threshold)
+			if (!$has_loaded_tags && $cache_enabled && isset($post[$edit_date]) && (microtime(true) - $time)*1000 > $cache_threshold)
 			{
-				$bbcodesModel->setBbCodeTagCache($content_type, $post_id, $tag_cache);
+				$bbcodesModel->setBbCodeTagCache($content_type, $post_id, $post[$edit_date], $bbmRecursiveMode, $tag_cache);
 			}
 		}
 

--- a/upload/library/BBM/DataWriter/Post.php
+++ b/upload/library/BBM/DataWriter/Post.php
@@ -15,12 +15,18 @@ class BBM_DataWriter_Post extends XFCP_BBM_DataWriter_Post
 
 	protected function _InvalidateCaches()
 	{
-		$this->_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), array());    
+		$this->_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), $this->getExisting('last_edit_date'), false, array());
+        $this->_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), $this->getExisting('last_edit_date'), true, array());
+        if ($this->isChanged('last_edit_date'))
+        {
+            $this->_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), $this->get('last_edit_date'), false, array());
+            $this->_getBbCodesModel()->setBbCodeTagCache('post', $this->get('post_id'), $this->get('last_edit_date'), true, array());
+        }
 	}
 
-	protected function _postSaveAfterTransaction()
+	protected function _messagePostSave()
 	{
-		parent::_postSaveAfterTransaction();
+		parent::_messagePostSave();
 		if ($this->isUpdate())
 		{
 			if ($this->isChanged('message') || ($this->isChanged('message_state') && $this->get('message_state') == 'deleted'))
@@ -28,6 +34,18 @@ class BBM_DataWriter_Post extends XFCP_BBM_DataWriter_Post
 				$this->_InvalidateCaches();
 			}
 		}
+	}
+
+	protected function _postSaveAfterTransaction()
+	{
+		if ($this->isUpdate())
+		{
+			if ($this->isChanged('message') || ($this->isChanged('message_state') && $this->get('message_state') == 'deleted'))
+			{
+				$this->_InvalidateCaches();
+			}
+		}
+		parent::_postSaveAfterTransaction();
 	}
 
 	protected function _messagePostDelete()

--- a/upload/library/BBM/Model/BbCodes.php
+++ b/upload/library/BBM/Model/BbCodes.php
@@ -700,7 +700,6 @@ class BBM_Model_BbCodes extends XenForo_Model
 		{
 			$options = XenForo_Application::get('options');
 			$this->TagMapCacheOptions = array(
-				'GlobalMethod' => $options->Bbm_TagsMap_GlobalMethod,
 				'Expiry'       => $options->Bbm_TagsMap_Cache_Expiry,
 				'EnableCache'  => $options->Bbm_TagsMap_Cache_Enabled,
 				'bbCodeCacheVersion'  => $options->bbCodeCacheVersion
@@ -709,7 +708,7 @@ class BBM_Model_BbCodes extends XenForo_Model
 		return $this->TagMapCacheOptions;
 	}
 
-	public function getBbCodeTagCache($content_type, $post_id)
+	public function getBbCodeTagCache($content_type, $post_id, $post_date, $bbmRecursiveMode)
 	{ 
 		if ($this->cacheObject === null)
 		{
@@ -722,7 +721,8 @@ class BBM_Model_BbCodes extends XenForo_Model
 			$cacheId = 'tagmap_'. $content_type . '_'.
 						$post_id . '_'.
 						$options['bbCodeCacheVersion'] . '_'.
-						($options['GlobalMethod'] ? "1" : "0")
+                        ($bbmRecursiveMode ? '1' : '0') . '_'.
+						$post_date
 						;
 			if ($raw = $this->cacheObject->load($cacheId, true))
 			{
@@ -732,7 +732,7 @@ class BBM_Model_BbCodes extends XenForo_Model
 		return array();
 	}    
 
-	public function setBbCodeTagCache($content_type, $post_id, array $tagMapCache)
+	public function setBbCodeTagCache($content_type, $post_id, $post_date, $bbmRecursiveMode, array $tagMapCache)
 	{  
 		if ($this->cacheObject === null)
 		{
@@ -746,7 +746,8 @@ class BBM_Model_BbCodes extends XenForo_Model
 			$cacheId = 'tagmap_'. $content_type . '_'.
 						$post_id . '_'.
 						$options['bbCodeCacheVersion'] . '_'.
-						($options['GlobalMethod'] ? "1" : "0")
+                        ($bbmRecursiveMode ? '1' : '0') . '_'.
+						$post_date
 						;
 			if (!empty($tagMapCache) && $options['EnableCache'])
 			{
@@ -755,8 +756,7 @@ class BBM_Model_BbCodes extends XenForo_Model
 			}
 			else
 			{
-				$data = false;
-                $this->cacheObject->remove($data);
+                $this->cacheObject->remove($cacheId);
 			}
 		}
 	}


### PR DESCRIPTION
Update tag mapping to track the last edit date to ensure consistent tag map cache invalidation, and ensure that the old tag map cache value is deleted.